### PR TITLE
update geo (complicated because of newish `HasKernel`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.29"
-geo = "0.14.0"
+geo = "0.17.0"
 num-traits = "0.2.8"
 thiserror = "1.0.4"
 
@@ -36,3 +36,4 @@ lto = true
 [[bench]]
 name = "benchmark"
 harness = false
+

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,7 +1,6 @@
 use crate::polylabel;
-use geo::{LineString, Point, Polygon};
+use geo::{GeoFloat, LineString, Point, Polygon};
 use libc::{c_double, c_void, size_t};
-use num_traits::{Float, Signed};
 use std::f64;
 use std::slice;
 
@@ -34,7 +33,7 @@ pub struct Position {
 // convert a Polylabel result Point into values that can be sent across the FFI boundary
 impl<T> From<Point<T>> for Position
 where
-    T: Float + Signed,
+    T: GeoFloat,
 {
     fn from(point: Point<T>) -> Position {
         Position {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 //! This crate provides a Rust implementation of the [Polylabel](https://github.com/mapbox/polylabel) algorithm
 //! for finding the optimum position of a polygon label.
 use geo::prelude::*;
-use geo::{Point, Polygon};
-use num_traits::{Float, FromPrimitive, Signed};
+use geo::{GeoFloat, Point, Polygon};
+use num_traits::FromPrimitive;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::iter::Sum;
@@ -23,7 +23,7 @@ pub use crate::ffi::{polylabel_ffi, Array, Position, WrapperArray};
 #[derive(Debug)]
 struct Qcell<T>
 where
-    T: Float + Signed,
+    T: GeoFloat
 {
     // The cell's centroid
     centroid: Point<T>,
@@ -37,7 +37,7 @@ where
 
 impl<T> Qcell<T>
 where
-    T: Float + Signed,
+    T: GeoFloat,
 {
     fn new(x: T, y: T, h: T, distance: T, max_distance: T) -> Qcell<T> {
         Qcell {
@@ -51,7 +51,7 @@ where
 
 impl<T> Ord for Qcell<T>
 where
-    T: Float + Signed,
+    T: GeoFloat,
 {
     fn cmp(&self, other: &Qcell<T>) -> std::cmp::Ordering {
         self.max_distance.partial_cmp(&other.max_distance).unwrap()
@@ -59,20 +59,20 @@ where
 }
 impl<T> PartialOrd for Qcell<T>
 where
-    T: Float + Signed,
+    T: GeoFloat,
 {
     fn partial_cmp(&self, other: &Qcell<T>) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-impl<T> Eq for Qcell<T> where T: Float + Signed {}
+impl<T> Eq for Qcell<T> where T: GeoFloat {}
 impl<T> PartialEq for Qcell<T>
 where
-    T: Float + Signed,
+    T: GeoFloat,
 {
     fn eq(&self, other: &Qcell<T>) -> bool
     where
-        T: Float,
+        T: GeoFloat,
     {
         self.max_distance == other.max_distance
     }
@@ -82,7 +82,7 @@ where
 /// Returned value is negative if the point is outside the polygon's exterior ring
 fn signed_distance<T>(x: &T, y: &T, polygon: &Polygon<T>) -> T
 where
-    T: Float,
+    T: GeoFloat,
 {
     let point = Point::new(*x, *y);
     let inside = polygon.contains(&point);
@@ -102,7 +102,7 @@ fn add_quad<T>(
     new_height: &T,
     polygon: &Polygon<T>,
 ) where
-    T: Float + Signed,
+    T: GeoFloat,
 {
     let two = T::one() + T::one();
     let centroid_x = cell.centroid.x();
@@ -158,7 +158,7 @@ fn add_quad<T>(
 ///
 pub fn polylabel<T>(polygon: &Polygon<T>, tolerance: &T) -> Result<Point<T>, PolylabelError>
 where
-    T: Float + FromPrimitive + Signed + Sum,
+    T: GeoFloat + FromPrimitive + Sum,
 {
     // special case for degenerate polygons
     if polygon.signed_area() == T::zero() {


### PR DESCRIPTION
I wanted to update the geo dependency, but hit the compiler error:

```
error[E0599]: no method named `contains` found for reference `&geo::Polygon<T>` in the current scope
  --> src/lib.rs:88:26
   |
88 |     let inside = polygon.contains(&point);
   |                          ^^^^^^^^ method not found in `&geo::Polygon<T>`
```

This is because we've further constrained `T` in geo for many of our algorithms to only work for the new HasKernel trait. 

This builds, but seems a little ugly. It's a draft because it depends upon resolving https://github.com/georust/geo/issues/577.